### PR TITLE
Add 800% zoom option and add toggle for zoom smoothing

### DIFF
--- a/imgeditor.js
+++ b/imgeditor.js
@@ -68,7 +68,7 @@ define(function(require, exports, module) {
                 "dark": "#3D3D3D",
                 "dark-gray": "#3D3D3D" 
             };
-            var img, canvas, activeDocument, rect, crop, zoom, info, rectinfo;
+            var img, canvas, activeDocument, rect, crop, zoom, smooth, info, rectinfo;
             var editor;
             
             plugin.on("draw", function(e) {
@@ -86,6 +86,7 @@ define(function(require, exports, module) {
                 editor = plugin.getElement("imgEditor");
                 crop = plugin.getElement("btn2");
                 zoom = plugin.getElement("zoom");
+                smooth = plugin.getElement("smooth");
                 info = plugin.getElement("info");
                 rectinfo = plugin.getElement("rectinfo");
                 
@@ -137,6 +138,37 @@ define(function(require, exports, module) {
                     tbHeight.setValue(canvas().offsetHeight);
                 });
                 
+                // smooth
+                smooth.on("afterchange", function(e) {
+                    if (smooth.checked) {
+                        ui.setStyleRule(".imgeditor canvas",
+                            "-ms-interpolation-mode", "bicubic");
+                        ui.setStyleRule(".imgeditor canvas",
+                            "image-rendering", "auto");
+                    }
+                    else {
+                        ui.setStyleRule(".imgeditor canvas",
+                            "-ms-interpolation-mode", "nearest-neighbor");
+                        ui.setStyleRule(".imgeditor canvas",
+                            "image-rendering", "-moz-crisp-edges");
+                        ui.setStyleRule(".imgeditor canvas",
+                            "image-rendering", "-o-crisp-edges");
+                        ui.setStyleRule(".imgeditor canvas",
+                            "image-rendering", "-webkit-optimize-contrast");
+                        ui.setStyleRule(".imgeditor canvas",
+                            "image-rendering", "optimize-contrast");
+                        ui.setStyleRule(".imgeditor canvas",
+                            "image-rendering", "pixelated");
+                    }
+
+                    var session = activeDocument.getSession();
+                    session.smooth = smooth.checked;
+
+                    settings.set("user/imgeditor/@smooth", smooth.checked);
+
+                    clearRect();
+                });
+
                 // Zoom
                 zoom.on("afterchange", function(e){
                     ui.setStyleRule(".imgeditor canvas", 
@@ -535,6 +567,8 @@ define(function(require, exports, module) {
                 // Set Toolbar
                 zoom.setValue(session.zoom || 100);
                 zoom.dispatchEvent("afterchange");
+                smooth.setValue(session.smooth);
+                smooth.dispatchEvent("afterchange");
                 
                 // Set Rect
                 if (session.rect) {

--- a/imgeditor.js
+++ b/imgeditor.js
@@ -149,16 +149,13 @@ define(function(require, exports, module) {
                     else {
                         ui.setStyleRule(".imgeditor canvas",
                             "-ms-interpolation-mode", "nearest-neighbor");
-                        ui.setStyleRule(".imgeditor canvas",
-                            "image-rendering", "-moz-crisp-edges");
-                        ui.setStyleRule(".imgeditor canvas",
-                            "image-rendering", "-o-crisp-edges");
-                        ui.setStyleRule(".imgeditor canvas",
-                            "image-rendering", "-webkit-optimize-contrast");
-                        ui.setStyleRule(".imgeditor canvas",
-                            "image-rendering", "optimize-contrast");
-                        ui.setStyleRule(".imgeditor canvas",
-                            "image-rendering", "pixelated");
+
+                        ["-moz-crisp-edges", "-o-crisp-edges", 
+                         "-webkit-optimize-contrast", "optimize-contrast",
+                         "pixelated"].map(function(prop) {
+                            ui.setStyleRule(".imgeditor canvas",
+                                "image-rendering", prop);
+                        });
                     }
 
                     var session = activeDocument.getSession();

--- a/imgeditor.xml
+++ b/imgeditor.xml
@@ -21,6 +21,7 @@
                 <a:item value="100">100%</a:item>
                 <a:item value="200">200%</a:item>
                 <a:item value="400">400%</a:item>
+                <a:item value="800">800%</a:item>
             </a:dropdown>
             <a:divider skin="c9-divider" />
             

--- a/imgeditor.xml
+++ b/imgeditor.xml
@@ -12,8 +12,8 @@
             <a:button skin="c9-toolbarbutton-glossy" id="btn5">FlipH</a:button>
             <a:button skin="c9-toolbarbutton-glossy" id="btn6">FlipV</a:button>
             <a:divider skin="c9-divider" />
-            
-            <a:dropdown skin="black_dropdown" id="zoom" value="100%" width="70" maxitems="7">
+
+            <a:dropdown skin="black_dropdown" id="zoom" value="100%" width="70" maxitems="8">
                 <a:item value="10">10%</a:item>
                 <a:item value="25">25%</a:item>
                 <a:item value="50">50%</a:item>
@@ -23,6 +23,7 @@
                 <a:item value="400">400%</a:item>
                 <a:item value="800">800%</a:item>
             </a:dropdown>
+            <a:checkbox skin="checkbox_black" id="smooth" value="false">Smooth</a:checkbox>
             <a:divider skin="c9-divider" />
             
             <a:label id="info" />


### PR DESCRIPTION
Developers wanting to look at details for small images on high-resolution screens may prefer a higher zoom range. This PR adds support for an 800% zoom and also adds a toggle to the image editor to disable (or enable) zoom smoothing.

By default, browsers that use a canvas scale option (as is used by this editor for zoom) will apply a bicubic interpolation to an image, which isn't necessarily the most accurate representation of the image. Using an annoying number of CSS properties we can disable this default behavior in browsers.

Tested and functional in Chrome 46 (should work in 41+), Safari 9 (should work in 6.1+), Firefox 42 (should work with 6+).

Should also work with IE 11, but the scale transform doesn't seem to apply, so no zoom happens in that browser. MS Edge does not support interpolation options other than their default at all.

More complete list of compatibility [available here](http://caniuse.com/#feat=css-crisp-edges), with some motivation for the mechanism provided by [this Stack Overflow post](https://stackoverflow.com/questions/7615009/disable-interpolation-when-scaling-a-canvas).
